### PR TITLE
Fix #1 - yara package is unrelated to yara-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ requests == 2.22.0
 lief == 0.9.0
 python_magic == 0.4.15
 modules == 1.0.0
-yara == 3.10.0


### PR DESCRIPTION
Fixes #1  - the 'yara' package is unrelated to the 'yara-python' package, and isn't needed.  It was last updated in 2014 and only goes up to version 1.7.7